### PR TITLE
added support to filter by issuetype (similar to how priority list did it)

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -4,8 +4,8 @@ var baseUrl = documentUrl.substring(0, documentUrl.indexOf('/secure/'));
 var hoverDescription, showLastComment, relatedCards, fixVersion;
 var statusCounts = {};
 var statusStoryPoints = {};
-var workFields = "&maxResults=1000&fields=key,priority,created,updated,status,summary,description,parent,labels,subtasks,assignee,issuelinks,fixVersions,comment,components," + storyPointsField + extraFields;
-var planFields = "&maxResults=1000&fields=key,priority,created,updated,status,summary,description,parent,labels,subtasks,assignee,issuelinks,fixVersions,comment,components" + planExtraFields;
+var workFields = "&maxResults=1000&fields=key,priority,created,updated,status,summary,description,parent,labels,subtasks,assignee,issuelinks,fixVersions,comment,components,issuetype," + storyPointsField + extraFields;
+var planFields = "&maxResults=1000&fields=key,priority,created,updated,status,summary,description,parent,labels,subtasks,assignee,issuelinks,fixVersions,comment,components,issuetype," + planExtraFields;
 var planIssueQuery = " and issuetype in standardIssueTypes() and ((sprint is empty and resolutiondate is empty) or sprint in openSprints() or sprint in futureSprints())"
 var workIssueQuery = " and (sprint in openSprints())";
 var kanbanIssueQuery = "";
@@ -164,6 +164,7 @@ function processIssues(data){
         var issueIsPR = jiraGithub.addPullRequestLabel(issue.key, elIssue);
         addHovercardTo(elIssue, fields, issue.key);
         addUserFilter('Unassigned');
+        addIssueTypeFilter('Hide all sub-tasks');
         addLabelTo(elIssue, createLabelFrom(fields.labels, issueIsPR, elIssue), 'top-right');
         addAttributesTo(elIssue, fields, issueIsPR);
         addOpenIssueLinkTo(elIssue, issue.key);
@@ -298,6 +299,7 @@ function addPluginMenu(){
             <a href='javascript:pluginShowUserFilter();' id='userFilter' title='User Filters' class='masterTooltip'><img width=16 height=16 src=" + chrome.extension.getURL('images/users.png') + "></a>  \
             <a href='javascript:pluginShowPriorityFilter();' id='priorityFilter' title='Priority Filters' class='masterTooltip'><img width=16 height=16 src=" + chrome.extension.getURL('images/priority2.png') + "></a>  \
             <a href='javascript:pluginShowFixVersionFilter();' id='fixversionFilter' title='FixVersion Filters' class='masterTooltip'><img width=16 height=16 src=" + chrome.extension.getURL('images/priority2.png') + "></a>  \
+            <a href='javascript:pluginShowIssuetypeFilter();' id='issuetypeFilter' title='Issuetype Filters' class='masterTooltip'><img width=16 height=16 src=" + chrome.extension.getURL('images/priority2.png') + "></a>  \
             <a href='javascript:pluginToggleStatus();' title='Issue Status' class='masterTooltip'><img width=16 height=16 src=" + chrome.extension.getURL('images/status.png') + "></a>  \
             <a id='pluginMentionCount' href='javascript:pluginMention();' title='You are mentioned' class='masterTooltip'></a>")
         .append("<a href='javascript:pluginRelease();' id='release' title='Release Notes' class='masterTooltip'><img width=16 height=16 src=" + chrome.extension.getURL('images/notes.png') + "></a>")
@@ -315,6 +317,9 @@ function addPluginMenu(){
             <div id='intu-filter-fixversion' class='intu-container'> \
                 <a href='javascript:pluginClose();' class='close-button'>Close</a>\
                 <strong>Filter By Fix Versions:</strong> <a href='javascript:pluginClearFilter()' style='color:red'>Clear Filter</a></div> \
+            <div id='intu-filter-issuetype' class='intu-container'>  \
+                <a href='javascript:pluginClose();' class='close-button'>Close</a>\
+                <strong>Filter By Issue Types:</strong> <a href='javascript:pluginClearFilter()' style='color:red'>Clear Filter</a></div> \
             <div id='intu-status'>  \
                 <a href='javascript:pluginClose();' class='close-button'>Close</a>\
                 <div id='num-of-issues'><strong># of Issues : </strong><span id='intu-status-issues'></span></div>  \
@@ -365,6 +370,10 @@ function addAttributesTo(elIssue, fields, issueIsPR){
     var priority = '';
     if (fields.priority) priority = fields.priority.name;
 
+    var issuetype = '';
+    if (fields.issuetype) issuetype = fields.issuetype.name;
+    console.log(fields.issuetype.name)
+
     var fixVersions = '';
     if (fields.fixVersions) {
         console.log(fields.fixVersions)
@@ -401,6 +410,7 @@ function addAttributesTo(elIssue, fields, issueIsPR){
     elIssue.attr('_watchers', watchers);
     elIssue.attr('_priority', priority);
     elIssue.attr('_fixVersion', fixVersions);
+    elIssue.attr('_issuetype', issuetype);
 
     // Add name filter
     addUserFilter(displayName);
@@ -410,6 +420,9 @@ function addAttributesTo(elIssue, fields, issueIsPR){
 
     //Add fix version filter
     addFixVersionFilter(fixVersions);
+
+    //Add the issuetype filter
+    addIssueTypeFilter(issuetype);
 
     if(fields.components){
         for(var i=0; i<fields.components.length; i++){

--- a/lc-jira-color.css
+++ b/lc-jira-color.css
@@ -91,7 +91,7 @@
     color: red;
 }
 
-#intu-status, #intu-release, #intu-filter-users, #intu-filter-priorities, #intu-filter-fixversion, #intu-mention, #intu-filter-components {
+#intu-status, #intu-release, #intu-filter-users, #intu-filter-priorities, #intu-filter-issuetype, #intu-filter-fixversion, #intu-mention, #intu-filter-components {
     display: none;
     position: absolute;
     width: 500px;
@@ -124,7 +124,7 @@
 
 #intu-menu-toggle { font-weight: bold; }
 
-.intu-filter-user, .intu-filter-priority, .intu-filter-fixversion,  .intu-filter-component { padding: 0 5px; }
+.intu-filter-user, .intu-filter-priority, .intu-filter-issuetype, .intu-filter-fixversion,  .intu-filter-component { padding: 0 5px; }
 
 .intu-filter-new-user { color: rgb(239, 4, 255) !important; }
 

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
     "persistent": false
   },
   "name": "JIRA on Steroid",
-  "version": "5.3",
+  "version": "5.4",
   "options_page": "options.html",
   "content_scripts": [
     {

--- a/script.js
+++ b/script.js
@@ -279,6 +279,11 @@ function pluginShowFixVersionFilter(){
     $('#intu-filter-fixversion').toggle();
 }
 
+function pluginShowIssuetypeFilter(){
+    pluginClose();
+    $('#intu-filter-issuetype').toggle();
+}
+
 function pluginShowComponentFilter(){
     pluginClose();
     $('#intu-filter-components').toggle();
@@ -305,6 +310,12 @@ function pluginFilterFixVersion(name){
     $('.ghx-issue, .ghx-issue-compact').hide();
     $(".ghx-issue[_fixVersion='" + name + "']").show();
     $(".ghx-issue-compact[_fixVersion='" + name + "']").show();
+}
+
+function pluginFilterIssuetype(name){
+    $('.ghx-issue, .ghx-issue-compact').hide();
+    $(".ghx-issue[_issuetype='" + name + "']").show();
+    $(".ghx-issue-compact[_issuetype='" + name + "']").show();
 }
 
 function pluginFilterComponent(name){

--- a/utils.js
+++ b/utils.js
@@ -124,6 +124,17 @@ function addFixVersionFilter(name){
     }
 }
 
+function addIssueTypeFilter(name){
+    if($(".intu-filter-issuetype[_displayName='" + name + "']").length == 0){
+        var link = $('<a />').attr({
+            class: 'intu-filter-issuetype',
+            href: "javascript:pluginFilterIssuetype('" + name + "')",
+            _displayName: name
+        }).text(name);
+        $('#intu-filter-issuetype').append(link);
+    }
+}
+
 function issueLinkJsHtml(issueKey, cssClass){
     var anchor = $('<a />').attr({
         href: "javascript:void(0);",


### PR DESCRIPTION
I added the "hide sub-task option" but it doesn't do anything. I would have to look into the code more and I don't really have the time for that. Feel free to exclude it or change it around. Essentially we want to also check fields.issuetype.subtask and see if it is false/true and store that somewhere. So we can then filter all the ones that are true. 

Also need a new .png for the issuetype.
